### PR TITLE
fix: change naming convention of response properties

### DIFF
--- a/src/main/java/com/jp/movieapi/component/movie/domain/Movie.java
+++ b/src/main/java/com/jp/movieapi/component/movie/domain/Movie.java
@@ -7,17 +7,17 @@ public class Movie {
     private UUID id;
     private String title;
     private String year;
-    private UUID directorId;
+    private UUID director_id;
     private List<UUID> genre;
-    private List<UUID> movieCast;
+    private List<UUID> movie_cast;
 
     public Movie(UUID id, String title, String year, UUID directorId, List<UUID> genre, List<UUID> movieCast) {
         this.id = id;
         this.title = title;
         this.year = year;
-        this.directorId = directorId;
+        this.director_id = directorId;
         this.genre = genre;
-        this.movieCast = movieCast;
+        this.movie_cast = movieCast;
     }
 
     public UUID getId() {
@@ -32,15 +32,15 @@ public class Movie {
         return year;
     }
 
-    public UUID getDirectorId() {
-        return directorId;
+    public UUID getDirector_id() {
+        return director_id;
     }
 
     public List<UUID> getGenre() {
         return genre;
     }
 
-    public List<UUID> getMovieCast() {
-        return movieCast;
+    public List<UUID> getMovie_cast() {
+        return movie_cast;
     }
 }


### PR DESCRIPTION
## Changlogs

* Change naming convention of properties in response (i.e., `camelCase` to `snake_case`).

## Screenshots

<img width="1044" height="694" alt="Screen Shot 2025-09-22 at 10 02 35 AM" src="https://github.com/user-attachments/assets/386daf1a-5fad-4567-ae45-7dfba1093092" />
